### PR TITLE
Fixed Item Data Not Loading Correctly

### DIFF
--- a/LethalThings/MonoBehaviours/SaveableObject.cs
+++ b/LethalThings/MonoBehaviours/SaveableObject.cs
@@ -27,7 +27,7 @@ namespace LethalThings.MonoBehaviours
         public override void OnNetworkSpawn()
         {
             base.OnNetworkSpawn();
-            if (IsHost)
+            if (IsHost && !uniqueId)
             {
                 uniqueId = UnityEngine.Random.Range(0, 100000000);
 


### PR DESCRIPTION
Fixed a bug that caused saved items to not retain their values (rocket launcher, flare gun)

The bug was caused by SaveableObject -> OnNetworkSpawn overwriting the uniqueId field already written by SaveableObject -> LoadItemSaveData