### PR TITLE
ItemCharger_Update override value fix

### DIFF
--- a/LethalThings/Patches/PowerOutletStun.cs
+++ b/LethalThings/Patches/PowerOutletStun.cs
@@ -53,10 +53,10 @@ namespace LethalThings.Patches
             orig(self);
             if (self.updateInterval == 0f)
             {
-                if (GameNetworkManager.Instance != null && GameNetworkManager.Instance.localPlayerController != null)
+                if (GameNetworkManager.Instance != null && GameNetworkManager.Instance.localPlayerController != null
+                    && GameNetworkManager.Instance.localPlayerController.currentlyHeldObjectServer != null && (GameNetworkManager.Instance.localPlayerController.currentlyHeldObjectServer.itemProperties.requiresBattery || GameNetworkManager.Instance.localPlayerController.currentlyHeldObjectServer.itemProperties.isConductiveMetal))
                 {
-                    self.triggerScript.interactable = GameNetworkManager.Instance.localPlayerController.currentlyHeldObjectServer != null && (GameNetworkManager.Instance.localPlayerController.currentlyHeldObjectServer.itemProperties.requiresBattery || GameNetworkManager.Instance.localPlayerController.currentlyHeldObjectServer.itemProperties.isConductiveMetal);
-                    return;
+                    self.triggerScript.interactable = true;
                 }
             }
         }


### PR DESCRIPTION
Fixed ItemCharger_Update overriding vanilla values when condition is not valid
This allows other mods to set their own interactable bool values whenever the LethalThings condition returns false